### PR TITLE
Fix torchmd and schnet import

### DIFF
--- a/matdeeplearn/models/schnet.py
+++ b/matdeeplearn/models/schnet.py
@@ -15,7 +15,7 @@ from torch_scatter import scatter, scatter_add, scatter_max, scatter_mean
 
 from matdeeplearn.common.registry import registry
 from matdeeplearn.models.base_model import BaseModel, conditional_grad
-from matdeeplearn.preprocessor.helpers import GaussianSmearing
+from matdeeplearn.preprocessor.helpers import GaussianSmearing, node_rep_one_hot
 
 @registry.register_model("SchNet")
 class SchNet(BaseModel):

--- a/matdeeplearn/models/torchmd_etEarly.py
+++ b/matdeeplearn/models/torchmd_etEarly.py
@@ -15,6 +15,7 @@ from matdeeplearn.models.utils import (
 from matdeeplearn.models.base_model import BaseModel, conditional_grad
 from matdeeplearn.models.torchmd_output_modules import Scalar, EquivariantScalar
 from matdeeplearn.common.registry import registry
+from matdeeplearn.preprocessor.helpers import node_rep_one_hot
 @registry.register_model("torchmd_etEarly")
 
 


### PR DESCRIPTION
torchmd and schnet were calling node_rep_one_hot without importing it from helpers, leading at least torchmd to fail.