### PR TITLE
Use torch_geometric.utils for scatter

### DIFF
--- a/matdeeplearn/models/torchmd_etEarly.py
+++ b/matdeeplearn/models/torchmd_etEarly.py
@@ -4,7 +4,7 @@ import torch.nn.functional as F
 from torch import Tensor, nn
 import torch_geometric.nn
 from torch_geometric.nn import MessagePassing
-from torch_scatter import scatter
+from torch_geometric.utils import scatter
 from matdeeplearn.models.utils import (
     NeighborEmbedding,
     CosineCutoff,


### PR DESCRIPTION
Necessary for vmap, and reduces dependence on torch_scatter (though it is used for other models)