### PR TITLE
Allow all-non-positive cells

### DIFF
--- a/matdeeplearn/preprocessor/helpers.py
+++ b/matdeeplearn/preprocessor/helpers.py
@@ -45,7 +45,7 @@ def calculate_edges_master(
     cell_offset_distances = torch.empty(0)
 
     #check if cell consists of all zeros; if a cell is not present when processing input data, it is set to torch.zeros()
-    if not torch.any(cell>0.0):
+    if torch.sum(torch.abs(cell)) == 0:
         cell = None
         method = "mdl"
 


### PR DESCRIPTION
The check used to be `if torch.sum(cell) == 0`, but there were certain symmetric cells for which the positive and negative values in the cell tensor perfectly cancelled each other out.

Then the check was changed to `if not torch.any(cell > 0)`, which fixed that problem, but rejects valid cells that are rotated such that they have all non-positive entries. One example is below:
`tensor([[[-1.5825, -4.5589, -2.6977],
         [-4.8258,  0.0000, -2.6977],
         [ 0.0000,  0.0000, -5.5286]]], device='cuda:0')`

I propose that this check now be `if torch.sum(torch.abs(cell)) == 0` which should only catch cells where every entry is exactly zero.